### PR TITLE
Bump webpack versions 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "react-scripts": "^1.0.7",
     "react-test-renderer": "^15.5.4",
-    "webpack": "^1.14.0",
+    "webpack": "^3.6.0",
     "webpack-dev-server": "^1.16.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "react-scripts": "^1.0.7",
     "react-test-renderer": "^15.5.4",
     "webpack": "^3.6.0",
-    "webpack-dev-server": "^1.16.2"
+    "webpack-dev-server": "^2.9.1"
   },
   "dependencies": {
     "babel-core": "^6.22.1",


### PR DESCRIPTION
@Lukeghenco 
Bumped webpack and webpack-dev-server versions. Current version (^1.14.0) causing `cannot read property 'request' of undefined` error.